### PR TITLE
dev(hansbug): use new hbutils

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -16,3 +16,4 @@ where>=1.0.2
 rarfile>=3
 py7zr>=0.19
 time-machine>=2.8.1
+pandas>=1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-hbutils>=0.7.4
+hbutils>=0.7.5
 pip>=20
 validators>=0.20.0
 psutil>=5.9.0

--- a/templates/test/inquirer.py
+++ b/templates/test/inquirer.py
@@ -1,5 +1,6 @@
 import os
 
+import pandas as pd  # Test the usage of pandas
 from InquirerPy import inquirer
 
 from igm.conf import InquireRestart, InquireCancel
@@ -11,6 +12,7 @@ _LAST_GENDER = "Male"
 
 
 def inquire_func():
+    _ = pd
     if os.environ.get('CANCEL'):
         raise InquireCancel
 


### PR DESCRIPTION
When you use `hbutils<=0.7.4`, you will find that when `import pandas` is used in inquirer script, it will cause error!

This is because of the usage of `__import__`, and older version of hbutils is not compitable with that.